### PR TITLE
Fix afs-client conflict with osg-ca-scripts and osg-ca-certs

### DIFF
--- a/bundles.ini
+++ b/bundles.ini
@@ -96,8 +96,8 @@ patchdirs   = patches/wn-client/common
               patches/afs-client/3.3/%(dver)s
 dirname     = osg-afs-client
 tarballname = osg-afs-client-%(version)s-%(relnum)s.%(dver)s.%(basearch)s.tar.gz
-packages    = osg-wn-client osg-update-data
-              globus-common-progs  globus-gram-client-tools  globus-gsi-cert-utils-progs  gsi-openssh-clients  osg-cert-scripts  vo-client
+packages    = osg-wn-client osg-update-data osg-ca-scripts
+              globus-common-progs  globus-gram-client-tools  globus-gsi-cert-utils-progs  gsi-openssh-clients  osg-cert-scripts
 repofile    = repos/osg-3.3.repo.in
 versionrpm  = osg-version
 stage1file  = osg-stage1.lst


### PR DESCRIPTION
- Don't bring in vo-client (osg-update-data will do that for us now)
- Explicitly get osg-ca-scripts, hopefully that will satisfy the
grid-certificates dependency and keep osg-ca-certs from being brought in