### PR TITLE
Remove osg-update-data from 3.3 tarballs and put vo-client back (SOFTWARE-2528)

### DIFF
--- a/bundles.ini
+++ b/bundles.ini
@@ -82,7 +82,7 @@ patchdirs   = patches/wn-client/common
               patches/wn-client/3.3/%(dver)s
 dirname     = osg-wn-client
 tarballname = osg-wn-client-%(version)s-%(relnum)s.%(dver)s.%(basearch)s.tar.gz
-packages    = osg-wn-client osg-update-data
+packages    = osg-ca-scripts osg-wn-client
 repofile    = repos/osg-3.3.repo.in
 versionrpm  = osg-version
 stage1file  = osg-stage1.lst
@@ -96,8 +96,8 @@ patchdirs   = patches/wn-client/common
               patches/afs-client/3.3/%(dver)s
 dirname     = osg-afs-client
 tarballname = osg-afs-client-%(version)s-%(relnum)s.%(dver)s.%(basearch)s.tar.gz
-packages    = osg-wn-client osg-update-data osg-ca-scripts
-              globus-common-progs  globus-gram-client-tools  globus-gsi-cert-utils-progs  gsi-openssh-clients  osg-cert-scripts
+packages    = osg-wn-client  osg-ca-scripts
+              globus-common-progs  globus-gram-client-tools  globus-gsi-cert-utils-progs  gsi-openssh-clients  osg-cert-scripts  vo-client
 repofile    = repos/osg-3.3.repo.in
 versionrpm  = osg-version
 stage1file  = osg-stage1.lst


### PR DESCRIPTION
osg-update-vos currently breaks if osg-release is not installed on the
system, which can occur in tarball installs. Revert the bundle
definition to what it was before osg-update-vos/osg-update-data.

This change should be reverted once osg-update-vos is fixed to work with
a tarball install where osg-release is not installed.