### PR TITLE
Add hosted-ce-tools to osg-wn-client bundles (SOFTWARE-4722)

### DIFF
--- a/bundles.ini
+++ b/bundles.ini
@@ -106,6 +106,7 @@ patchdirs   = patches/wn-client/common
 dirname     = osg-wn-client
 tarballname = osg-wn-client-%(version)s-%(relnum)s.%(dver)s.%(basearch)s.tar.gz
 packages    = osg-wn-client osg-update-data
+              hosted-ce-tools
 repofile    = repos/osg-3.5-%(dver)s.repo.in
 stage1file  = osg-stage1-%(dver)s.lst
 
@@ -118,6 +119,7 @@ patchdirs   = patches/wn-client/common
 dirname     = osg-wn-client
 tarballname = osg-wn-client-%(version)s-%(relnum)s.%(dver)s.%(basearch)s.tar.gz
 packages    = osg-wn-client osg-update-data
+              hosted-ce-tools
 repofile    = repos/osg-3.6-%(dver)s.repo.in
 stage1file  = osg-stage1-%(dver)s.lst
 

--- a/repos/osg-3.5-el7.repo.in
+++ b/repos/osg-3.5-el7.repo.in
@@ -21,8 +21,8 @@ gpgcheck = 0
 baseurl = http://koji.chtc.wisc.edu/mnt/koji/repos/osg-3.5-%(dver)s-testing/latest/%(basearch)s/
 name = osg-3.5-%(dver)s-testing (%(basearch)s)
 failovermethod = priority
-enabled = 0
-#includepkgs =
+enabled = 1
+includepkgs = hosted-ce-tools
 
 [devops-production]
 priority = 98

--- a/repos/osg-3.5-el8.repo.in
+++ b/repos/osg-3.5-el8.repo.in
@@ -54,8 +54,8 @@ gpgcheck = 0
 baseurl = https://repo.opensciencegrid.org/osg/3.5/%(dver)s/testing/%(basearch)s/
 #baseurl = http://koji.chtc.wisc.edu/mnt/koji/repos/osg-3.5-%(dver)s-testing/latest/%(basearch)s/
 name = osg-3.5-%(dver)s-testing (%(basearch)s)
-enabled = 0
-#includepkgs =
+enabled = 1
+includepkgs = hosted-ce-tools
 
 [devops-production-for-tarball]
 priority = 98

--- a/repos/osg-3.6-el7.repo.in
+++ b/repos/osg-3.6-el7.repo.in
@@ -21,8 +21,8 @@ gpgcheck = 0
 baseurl = http://koji.chtc.wisc.edu/mnt/koji/repos/osg-3.6-%(dver)s-testing/latest/%(basearch)s/
 name = osg-3.6-%(dver)s-testing (%(basearch)s)
 failovermethod = priority
-enabled = 0
-#includepkgs =
+enabled = 1
+includepkgs = hosted-ce-tools
 
 [devops-production]
 priority = 98

--- a/repos/osg-3.6-el8.repo.in
+++ b/repos/osg-3.6-el8.repo.in
@@ -54,8 +54,8 @@ gpgcheck = 0
 baseurl = https://repo.opensciencegrid.org/osg/3.6/%(dver)s/testing/%(basearch)s/
 #baseurl = http://koji.chtc.wisc.edu/mnt/koji/repos/osg-3.6-%(dver)s-testing/latest/%(basearch)s/
 name = osg-3.6-%(dver)s-testing (%(basearch)s)
-enabled = 0
-#includepkgs =
+enabled = 1
+includepkgs = hosted-ce-tools
 
 [devops-production-for-tarball]
 priority = 98


### PR DESCRIPTION
Take it from testing because the version (0.11) isn't in release yet.