### PR TITLE
Drop 'failovermethod' line -- it is no longer understood by dnf/yum on CentOS 8

### DIFF
--- a/repos/osg-3.3.repo.in
+++ b/repos/osg-3.3.repo.in
@@ -3,7 +3,6 @@ priority = 98
 gpgcheck = 0
 baseurl = http://koji.chtc.wisc.edu/mnt/koji/repos/osg-3.3-%(dver)s-development/latest/%(basearch)s/
 name = osg-3.3-%(dver)s-development (%(basearch)s)
-failovermethod = priority
 enabled = 0
 #includepkgs =
 
@@ -12,7 +11,6 @@ priority = 98
 gpgcheck = 0
 baseurl = http://koji.chtc.wisc.edu/mnt/koji/repos/osg-3.3-%(dver)s-release-build/latest/%(basearch)s/
 name = osg-3.3-%(dver)s-release-build (%(basearch)s)
-failovermethod = priority
 enabled = 1
 
 [osg-testing-limited]
@@ -20,7 +18,6 @@ priority = 98
 gpgcheck = 0
 baseurl = http://koji.chtc.wisc.edu/mnt/koji/repos/osg-3.3-%(dver)s-testing/latest/%(basearch)s/
 name = osg-3.3-%(dver)s-testing (%(basearch)s)
-failovermethod = priority
 enabled = 0
 #includepkgs =
 
@@ -32,6 +29,5 @@ priority = 97
 gpgcheck = 0
 baseurl = http://koji.chtc.wisc.edu/mnt/koji/repos/osg-3.3-%(dver)s-prerelease/latest/%(basearch)s/
 name = osg-3.3-%(dver)s-prerelease (%(basearch)s)
-failovermethod = priority
 enabled = 0
 

--- a/repos/osg-3.4.repo.in
+++ b/repos/osg-3.4.repo.in
@@ -3,7 +3,6 @@ priority = 98
 gpgcheck = 0
 baseurl = http://koji.chtc.wisc.edu/mnt/koji/repos/osg-3.4-%(dver)s-development/latest/%(basearch)s/
 name = osg-3.4-%(dver)s-development (%(basearch)s)
-failovermethod = priority
 enabled = 0
 #includepkgs =
 
@@ -12,7 +11,6 @@ priority = 98
 gpgcheck = 0
 baseurl = http://koji.chtc.wisc.edu/mnt/koji/repos/osg-3.4-%(dver)s-release-build/latest/%(basearch)s/
 name = osg-3.4-%(dver)s-release-build (%(basearch)s)
-failovermethod = priority
 enabled = 1
 
 [osg-testing-limited]
@@ -20,7 +18,6 @@ priority = 98
 gpgcheck = 0
 baseurl = http://koji.chtc.wisc.edu/mnt/koji/repos/osg-3.4-%(dver)s-testing/latest/%(basearch)s/
 name = osg-3.4-%(dver)s-testing (%(basearch)s)
-failovermethod = priority
 enabled = 0
 #includepkgs =
 
@@ -32,6 +29,5 @@ priority = 97
 gpgcheck = 0
 baseurl = http://koji.chtc.wisc.edu/mnt/koji/repos/osg-3.4-%(dver)s-prerelease/latest/%(basearch)s/
 name = osg-3.4-%(dver)s-prerelease (%(basearch)s)
-failovermethod = priority
 enabled = 0
 

--- a/repos/osg-3.5-el7.repo.in
+++ b/repos/osg-3.5-el7.repo.in
@@ -3,7 +3,6 @@ priority = 98
 gpgcheck = 0
 baseurl = http://koji.chtc.wisc.edu/mnt/koji/repos/osg-3.5-%(dver)s-development/latest/%(basearch)s/
 name = osg-3.5-%(dver)s-development (%(basearch)s)
-failovermethod = priority
 enabled = 0
 #includepkgs =
 
@@ -12,7 +11,6 @@ priority = 98
 gpgcheck = 0
 baseurl = http://koji.chtc.wisc.edu/mnt/koji/repos/osg-3.5-%(dver)s-release-build/latest/%(basearch)s/
 name = osg-3.5-%(dver)s-release-build (%(basearch)s)
-failovermethod = priority
 enabled = 1
 
 [osg-testing-limited]
@@ -20,7 +18,6 @@ priority = 98
 gpgcheck = 0
 baseurl = http://koji.chtc.wisc.edu/mnt/koji/repos/osg-3.5-%(dver)s-testing/latest/%(basearch)s/
 name = osg-3.5-%(dver)s-testing (%(basearch)s)
-failovermethod = priority
 enabled = 0
 includepkgs =
 
@@ -29,7 +26,6 @@ priority = 98
 gpgcheck = 0
 baseurl = http://koji.chtc.wisc.edu/mnt/koji/repos/devops-%(dver)s-production/latest/%(basearch)s/
 name = osg-devops-production (%(basearch)s)
-failovermethod = priority
 enabled = 1
 
 [devops-itb]
@@ -37,7 +33,6 @@ priority = 98
 gpgcheck = 0
 baseurl = http://koji.chtc.wisc.edu/mnt/koji/repos/devops-%(dver)s-itb/latest/%(basearch)s/
 name = osg-devops-itb (%(basearch)s)
-failovermethod = priority
 enabled = 1
 #includepkgs =
 
@@ -49,6 +44,5 @@ priority = 97
 gpgcheck = 0
 baseurl = http://koji.chtc.wisc.edu/mnt/koji/repos/osg-3.5-%(dver)s-prerelease/latest/%(basearch)s/
 name = osg-3.5-%(dver)s-prerelease (%(basearch)s)
-failovermethod = priority
 enabled = 1
 

--- a/repos/osg-3.6-el7.repo.in
+++ b/repos/osg-3.6-el7.repo.in
@@ -3,7 +3,6 @@ priority = 98
 gpgcheck = 0
 baseurl = http://koji.chtc.wisc.edu/mnt/koji/repos/osg-3.6-%(dver)s-development/latest/%(basearch)s/
 name = osg-3.6-%(dver)s-development (%(basearch)s)
-failovermethod = priority
 enabled = 0
 #includepkgs =
 
@@ -12,7 +11,6 @@ priority = 98
 gpgcheck = 0
 baseurl = http://koji.chtc.wisc.edu/mnt/koji/repos/osg-3.6-%(dver)s-release-build/latest/%(basearch)s/
 name = osg-3.6-%(dver)s-release-build (%(basearch)s)
-failovermethod = priority
 enabled = 1
 
 [osg-testing-limited]
@@ -20,7 +18,6 @@ priority = 98
 gpgcheck = 0
 baseurl = http://koji.chtc.wisc.edu/mnt/koji/repos/osg-3.6-%(dver)s-testing/latest/%(basearch)s/
 name = osg-3.6-%(dver)s-testing (%(basearch)s)
-failovermethod = priority
 enabled = 0
 includepkgs =
 
@@ -29,7 +26,6 @@ priority = 98
 gpgcheck = 0
 baseurl = http://koji.chtc.wisc.edu/mnt/koji/repos/devops-%(dver)s-production/latest/%(basearch)s/
 name = osg-devops-production (%(basearch)s)
-failovermethod = priority
 enabled = 1
 
 [devops-itb]
@@ -37,7 +33,6 @@ priority = 98
 gpgcheck = 0
 baseurl = http://koji.chtc.wisc.edu/mnt/koji/repos/devops-%(dver)s-itb/latest/%(basearch)s/
 name = osg-devops-itb (%(basearch)s)
-failovermethod = priority
 enabled = 1
 #includepkgs =
 
@@ -49,6 +44,5 @@ priority = 97
 gpgcheck = 0
 baseurl = http://koji.chtc.wisc.edu/mnt/koji/repos/osg-3.6-%(dver)s-prerelease/latest/%(basearch)s/
 name = osg-3.6-%(dver)s-prerelease (%(basearch)s)
-failovermethod = priority
 enabled = 1
 


### PR DESCRIPTION
This isn't related to yum priorities; I don't know what it did.