### PR TITLE
Add sudo to stage 1 list so it doesn't end up in the tarball

### DIFF
--- a/osg-stage1-el7.lst
+++ b/osg-stage1-el7.lst
@@ -14,6 +14,7 @@ openldap-clients
 openssl
 perl
 rpm
+sudo
 which
 yum
 zip

--- a/osg-stage1-el8.lst
+++ b/osg-stage1-el8.lst
@@ -7,6 +7,7 @@
 python36
 setroubleshoot-server
 setroubleshoot-plugins
+sudo
 # X libraries/GUI stuff
 abattis-cantarell-fonts
 cairo


### PR DESCRIPTION
Built osg-wn-client tarballs for 3.5 and 3.6, el7 and el8, for the old branch and the new branch, and compared the file lists. The change had no effect on the el8 tarballs (sudo was already not there). On el7 it removed:

```
etc/virc
etc/sudoers
etc/pam.d/
etc/pam.d/sudo
etc/pam.d/sudo-i
etc/sudo.conf
etc/sudo-ldap.conf
usr/libexec/sudo/
usr/libexec/sudo/sudoers.so
usr/libexec/sudo/group_file.so
usr/libexec/sudo/libsudo_util.so.0
usr/libexec/sudo/sudo_noexec.so
usr/libexec/sudo/libsudo_util.so.0.0.0
usr/libexec/sudo/system_group.so
usr/libexec/sudo/libsudo_util.so
usr/libexec/sudo/sesh
usr/lib/tmpfiles.d/
usr/lib/tmpfiles.d/sudo.conf
usr/share/man/man1/cvtsudoers.1.gz
usr/share/man/man1/rview.1.gz
usr/share/man/man1/vim.1.gz
usr/share/man/man1/rvi.1.gz
usr/share/man/man1/ex.1.gz
usr/share/man/man1/view.1.gz
usr/share/man/man1/vi.1.gz
usr/share/man/man5/sudoers.ldap.5.gz
usr/share/man/man5/sudoers_timestamp.5.gz
usr/share/man/man5/virc.5.gz
usr/share/man/man5/sudo-ldap.conf.5.gz
usr/share/man/man5/sudo.conf.5.gz
usr/share/man/man5/sudoers.5.gz
usr/share/man/man8/sudoreplay.8.gz
usr/share/man/man8/sudo.8.gz
usr/share/man/man8/visudo.8.gz
usr/share/man/man8/sudoedit.8.gz
usr/share/doc/sudo-1.8.23/
usr/share/doc/sudo-1.8.23/NEWS
usr/share/doc/sudo-1.8.23/HISTORY
usr/share/doc/sudo-1.8.23/schema.iPlanet
usr/share/doc/sudo-1.8.23/LICENSE
usr/share/doc/sudo-1.8.23/schema.OpenLDAP
usr/share/doc/sudo-1.8.23/README.LDAP
usr/share/doc/sudo-1.8.23/examples/
usr/share/doc/sudo-1.8.23/examples/syslog.conf
usr/share/doc/sudo-1.8.23/examples/sudoers
usr/share/doc/sudo-1.8.23/examples/pam.conf
usr/share/doc/sudo-1.8.23/examples/sudo.conf
usr/share/doc/sudo-1.8.23/ChangeLog
usr/share/doc/sudo-1.8.23/UPGRADE
usr/share/doc/sudo-1.8.23/CONTRIBUTORS
usr/share/doc/sudo-1.8.23/TROUBLESHOOTING
usr/share/doc/sudo-1.8.23/schema.ActiveDirectory
usr/share/doc/sudo-1.8.23/README
usr/sbin/visudo
usr/bin/vi
usr/bin/cvtsudoers
usr/bin/sudo
usr/bin/rvi
usr/bin/sudoreplay
usr/bin/ex
usr/bin/sudoedit
usr/bin/view
usr/bin/rview
```
(as a bonus, it got rid of `vi` too).