### PR TITLE
Fix GHA deprecation warning (SOFTWARE-5354)

### DIFF
--- a/.github/workflows/tarball-build-test.yml
+++ b/.github/workflows/tarball-build-test.yml
@@ -15,7 +15,7 @@ jobs:
       OS_VERSION: ${{ matrix.OS_VERSION }}
       OSG_VERSION: ${{ matrix.OSG_VERSION }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run Test Script
         run:
           sh tests/setup_tests.sh ${OS_VERSION}


### PR DESCRIPTION
Fix deprecated Node.js 12 action with update to Node.js 16.
