### PR TITLE
Various fixups

### DIFF
--- a/make-client-tarball
+++ b/make-client-tarball
@@ -9,7 +9,7 @@ elif test -x /usr/libexec/platform-python; then
     python=/usr/libexec/platform-python
 else
     echo >&2 "Can't find Python"
-    exit 255
+    exit 127
 fi
 
 exec "$python" "$(dirname "$0")/make_client_tarball.py" "$@"

--- a/yumconf.py
+++ b/yumconf.py
@@ -106,8 +106,8 @@ class YumInstaller(object):
             subprocess.call(["yum", "clean", "all"] + args, stdout=fnull)
 
     def _get_yum_major_version(self):
-        proc = subprocess.Popen("yum --version | head -n1", shell=True, stdout=subprocess.PIPE)
-        output = to_str(proc.communicate()[0]).strip()
+        proc = subprocess.Popen(["yum", "--version"], stdout=subprocess.PIPE)
+        output = to_str(proc.communicate()[0]).strip().splitlines()[0]
         version = output.split(".")
         try:
             return int(version[0])
@@ -125,7 +125,7 @@ class YumInstaller(object):
         cmd.extend(self.repo_args)
         cmd.extend(args)
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-        output = to_str(proc.communicate()[0])
+        output = to_str(proc.communicate()[0]).splitlines()[0]
         retcode = proc.returncode
 
         if not retcode:

--- a/yumconf.py
+++ b/yumconf.py
@@ -131,7 +131,10 @@ class YumInstaller(object):
         if not retcode:
             return output
         else:
-            raise subprocess.CalledProcessError("repoquery failed")
+            raise subprocess.CalledProcessError(retcode,
+                                                cmd,
+                                                output,
+                                                "")
 
 
     def install(self, installroot, packages):


### PR DESCRIPTION
- [Use correct signature for subprocess.CalledProcessError](https://github.com/opensciencegrid/tarball-client/commit/7960ab5db6e06a25552ec96c1ee4f61c1b69784f)
- [Handle multiple lines in "repoquery" output; also don't shell out just to call head(1)](https://github.com/opensciencegrid/tarball-client/commit/d4c07c3d4381276d14938fcc3f97c98240200e70) 
