### PR TITLE
SOFTWARE-5774: extract osgver from version

### DIFF
--- a/.github/workflows/tarball-build-test.yml
+++ b/.github/workflows/tarball-build-test.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        OS_TYPE: ["centos"]
-        OS_VERSION: [7, 8]
-        OSG_VERSION: [3.6]
+        OS_TYPE: ["almalinux"]
+        OS_VERSION: [8, 9]
+        OSG_VERSION: [3.6.123456, 23.123456]
     env:
       OS_TYPE: ${{ matrix.OS_TYPE }}
       OS_VERSION: ${{ matrix.OS_VERSION }}

--- a/make_client_tarball.py
+++ b/make_client_tarball.py
@@ -7,6 +7,7 @@ from optparse import OptionParser
 import shutil
 import tempfile
 import subprocess
+import re
 try:
     import ConfigParser
 except ImportError:
@@ -101,11 +102,10 @@ def make_tarball(bundlecfg, bundle, basearch, dver, packages, patch_dirs, prog_d
 
 def parse_cmdline_args(argv):
     parser = OptionParser("""
-    %prog [options] --osgver=<osgver> --dver=<dver> [--basearch=<basearch>]
-or: %prog [options] --osgver=<osgver> --all
+    %prog [options] --version=<version> --dver=<dver> [--basearch=<basearch>]
+or: %prog [options] --version=<version> --all
 """)
-    parser.add_option("-o", "--osgver", help="OSG Major Version (e.g 3.4). Either this or --bundle must be specified.")
-    parser.add_option("--version", default=None, help="Version of the tarball; will be taken from the versionrpm of the bundle, e.g. osg-version, if not specified")
+    parser.add_option("-v", "--version", default=None, help="Version of the tarball; will be taken from the versionrpm of the bundle, e.g. osg-version, if not specified")
     parser.add_option("-r", "--relnum", default="1", help="Release number. Default is %default.")
     parser.add_option("--prerelease", default=True, action="store_true", help="Take packages from the prerelease repository (the default)")
     parser.add_option("--no-prerelease", "--noprerelease", dest="prerelease", action="store_false", help="Do not take packages from the prerelease repository")
@@ -125,8 +125,12 @@ or: %prog [options] --osgver=<osgver> --all
     if not options.all and not options.dver:
         parser.error("Either --all or --dver must be specified.")
 
-    if not options.bundles and not options.osgver:
-        parser.error("--osgver or --bundle must be specified")
+    if not options.bundles and not options.version:
+        parser.error("--version or --bundle must be specified")
+
+    if options.version:
+        match = re.search(r'^[0-9.]+\.', options.version)
+        options.osgver = match.group()[0:-1]
 
     if options.prerelease:
         options.extra_repos = options.extra_repos or []

--- a/tests/setup_tests.sh
+++ b/tests/setup_tests.sh
@@ -3,8 +3,8 @@
 pkg_name=tarball-client
 image=
 case "${OS_TYPE}${OS_VERSION}" in
-    centos7) image=centos:centos7 ;;
-    centos8) image=quay.io/centos/centos:stream8 ;;
+    almalinux8) image=almalinux:8 ;;
+    almalinux9) image=almalinux:9 ;;
     *) echo >&2 "${OS_TYPE}${OS_VERSION} not supported"; exit 1 ;;
 esac
 

--- a/tests/test_inside_docker.sh
+++ b/tests/test_inside_docker.sh
@@ -14,16 +14,13 @@ rpm -U https://dl.fedoraproject.org/pub/epel/epel-release-latest-${OS_VERSION}.n
 # Broken mirror?
 echo "exclude=mirror.beyondhosting.net" >> /etc/yum/pluginconf.d/fastestmirror.conf
 
-yum -y install /bin/mount patch python2 yum-utils
+yum -y install /bin/mount patch python3 yum-utils
 if [[ $OS_VERSION -lt 8 ]]; then
     yum -y install yum-plugin-priorities
 fi
 
 pushd tarball-client
-args=(--osgver ${OSG_VERSION} --dver el${OS_VERSION} --basearch x86_64 --bundle osg-wn-client-${OSG_VERSION})
-if [[ $OSG_VERSION == 3.5 ]]; then
-    args+=(--version=3.5.99)
-fi
+args=(--version ${OSG_VERSION} --dver el${OS_VERSION} --basearch x86_64)
 ./make-client-tarball "${args[@]}"
 popd
 


### PR DESCRIPTION
In rewriting the how to cut a release document, I felt it was time to simplify invoking docker-make-client-tarball. There is no reason to have to both specify osgver and version when osgver can be easily extracted from version.