### PR TITLE
Drop kernel-srpm-macros from el9 stage1 file list

### DIFF
--- a/osg-stage1-el9.lst
+++ b/osg-stage1-el9.lst
@@ -29,7 +29,6 @@ libXtst
 annobin
 gcc
 gcc-c++
-kernel-srpm-macros
 libstdc++-devel
 lua-srpm-macros
 llvm-libs


### PR DESCRIPTION
This was causing perl-filetest to be installed into the stage1 instead of the stage2, which caused problems because osg-ca-manage needed it.