### PR TITLE
xrootd and pelican-server bundles

### DIFF
--- a/bundles.ini
+++ b/bundles.ini
@@ -199,3 +199,34 @@ repofile    = repos/ligo-el6.repo.in
 versionrpm  = glue
 stage1file  = ligo-stage1.lst
 
+[xrootd-for-pelican-el9]
+paramsets   = el9,x86_64
+dirname     = xrootd
+tarballname = xrootd-for-pelican-%(version)s-%(relnum)s.tar.gz
+;patchdirs   = patches/xrootd-for-pelican
+packages    = xrdcl-pelican
+              xrootd-multiuser
+              xrootd-s3-http
+              xrootd-scitokens
+              xrootd-server
+              xrootd-tcp-stats
+              xrootd-voms
+repofile    = repos/osg-25-%(dver)s.repo.in
+versionrpm  = xrootd
+stage1file  = xrootd-for-pelican-stage1-%(dver)s.lst
+
+[xrootd-for-pelican-el8]
+# el8 does not have xrootd-s3-http
+paramsets   = el8,x86_64
+dirname     = xrootd
+tarballname = xrootd-for-pelican-%(version)s-%(relnum)s.tar.gz
+;patchdirs   = patches/xrootd-for-pelican
+packages    = xrdcl-pelican
+              xrootd-multiuser
+              xrootd-scitokens
+              xrootd-server
+              xrootd-tcp-stats
+              xrootd-voms
+repofile    = repos/osg-25-%(dver)s.repo.in
+versionrpm  = xrootd
+stage1file  = xrootd-for-pelican-stage1-%(dver)s.lst

--- a/make_client_tarball.py
+++ b/make_client_tarball.py
@@ -75,7 +75,7 @@ def make_tarball(bundlecfg, bundle, basearch, dver, packages, patch_dirs, prog_d
     with yumconf.YumInstaller(repofile, dver, basearch, extra_repos) as yum:
         if not version:
             if bundlecfg.has_option(bundle, 'versionrpm'):
-                version = yum.repoquery(bundlecfg.get(bundle, 'versionrpm'), "--queryformat=%{VERSION}").rstrip()
+                version = yum.repoquery(bundlecfg.get(bundle, 'versionrpm'), "--latest-limit", "1", "--queryformat=%{VERSION}").rstrip()
             else:
                 version = 'unknown'
         tarball_path = bundlecfg.get(bundle, 'tarballname') % locals()

--- a/post-install/osg_post_install.py
+++ b/post-install/osg_post_install.py
@@ -182,14 +182,16 @@ def fix_osg_location_in_sysconfig_bestman2(staging_dir, final_osg_location):
         failure("Unable to fix BeSTMan2 sysconfig file for the following reason:\n%s" % err)
 
 
-def check_required_binaries():
+def check_required_binaries(staging_dir):
     """Make sure we have all the prerequisites for running the tarball install.
 
     """
     print_nonl("Checking for required binaries...")
-    if not os.path.exists("/usr/bin/perl"):
-        failure("/usr/bin/perl not found (run \"yum install perl\" to install)")
-        return False
+    if os.path.exists(os.path.join(staging_dir, "usr/sbin/fetch-crl")):
+        # We need perl for fetch-crl
+        if not os.path.exists("/usr/bin/perl"):
+            failure("/usr/bin/perl not found (run \"yum install perl\" to install)")
+            return False
     success()
     return True
 
@@ -246,10 +248,6 @@ def get_staging_dir(arg_staging_dir=None):
 def main(argv):
     options, args = parse_cmdline_args(argv)
 
-    if not check_required_binaries():
-        print("Required binaries not installed. Please install them.")
-        return 1
-
     if len(args) > 0:
         staging_dir = get_staging_dir(args[0])
     else:
@@ -258,6 +256,10 @@ def main(argv):
     if not staging_dir:
         print("No valid staging directory found.")
         return 2
+
+    if not check_required_binaries(staging_dir):
+        print("Required binaries not installed. Please install them.")
+        return 1
 
     if options.final_osg_location:
         print("Final OSG_LOCATION specified as %r" % (options.final_osg_location))

--- a/xrootd-for-pelican-stage1-el8.lst
+++ b/xrootd-for-pelican-stage1-el8.lst
@@ -1,0 +1,30 @@
+# Stage 1 packages
+# These packages will be installed into the tarball staging directory but their
+# files will be excluded from the tarball itself.
+# Packages may be separated by newline or whitespace.  Actual whitespace must
+# be quoted.
+@core
+python36
+setroubleshoot-server
+setroubleshoot-plugins
+sudo
+# X libraries/GUI stuff
+abattis-cantarell-fonts
+cairo
+fontconfig
+gsettings-desktop-schemas
+libX11
+libXau
+libXcursor
+libXdmcp
+libXext
+libXfixes
+libXft
+libXi
+libXinerama
+libXrandr
+libXrender
+libXtst
+# xrootd-specific dependencies that we want to exclude
+expect
+# vim:ft=conf

--- a/xrootd-for-pelican-stage1-el9.lst
+++ b/xrootd-for-pelican-stage1-el9.lst
@@ -1,0 +1,39 @@
+# Stage 1 packages
+# These packages will be installed into the tarball staging directory but their
+# files will be excluded from the tarball itself.
+# Packages may be separated by newline or whitespace.  Actual whitespace must
+# be quoted.
+@core
+python3
+setroubleshoot-server
+setroubleshoot-plugins
+sudo
+# X libraries/GUI stuff
+abattis-cantarell-fonts
+cairo
+fontconfig
+gsettings-desktop-schemas
+libX11
+libXau
+libXcursor
+libXdmcp
+libXext
+libXfixes
+libXft
+libXi
+libXinerama
+libXrandr
+libXrender
+libXtst
+# New in el9
+annobin
+gcc
+gcc-c++
+kernel-srpm-macros
+libstdc++-devel
+lua-srpm-macros
+llvm-libs
+pkgconf
+# xrootd-specific dependencies that we want to exclude
+expect
+


### PR DESCRIPTION
Dependencies are based on the dependencies listed in the .goreleaser.yml for pelican-server and the Requires lines in osdf-server.spec.

There are separate bundles for el8 vs el9 because xrootd-s3-http is not available in el8.

A few other changes were necessary -- picking the version number used in the version of the tarball was broken because it was looking at the version of the oldest RPM in the repo, not the newest.  Also, conditionalized the check for /usr/bin/perl based on whether or not fetch-crl was installed.